### PR TITLE
Step18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/application/useCase/CreatePaymentUseCaseImpl.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/application/useCase/CreatePaymentUseCaseImpl.java
@@ -32,7 +32,6 @@ public class CreatePaymentUseCaseImpl implements CreatePaymentUseCase {
   private final TokenService tokenService;
 
   private final PaymentEventPublisher eventPublisher;
-  private final ReservationEventPublisher reservationEventPublisher;
 
   private final PaymentMapper paymentMapper;
 

--- a/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/application/useCase/CreatePaymentUseCaseImpl.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/application/useCase/CreatePaymentUseCaseImpl.java
@@ -52,8 +52,10 @@ public class CreatePaymentUseCaseImpl implements CreatePaymentUseCase {
       eventPublisher.execute(new PaymentEvent(reservation.getId(), reservation.getReservedPrice(), user.getId(), command.getAccessKey()));
 
       return paymentMapper.of( reservation, user);
+    } catch (CustomException e){
+      throw new CustomException(e.getErrorCode());
     } catch (Exception e){
-      throw new CustomException(ErrorCode.UNSPECIFIED_FAIL);
+      throw new RuntimeException();
     }
   }
 

--- a/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/infrastructure/outbox/jpa/PaymentOutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/infrastructure/outbox/jpa/PaymentOutboxJpaRepository.java
@@ -2,6 +2,7 @@ package io.hhplus.concert_reservation_service_java.domain.payment.infrastructure
 
 import io.hhplus.concert_reservation_service_java.domain.common.outbox.Outbox;
 import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.repository.jpa.Payment;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,6 @@ public interface PaymentOutboxJpaRepository extends JpaRepository<PaymentOutbox,
   @Modifying
   @Query("DELETE FROM PaymentOutbox p WHERE p.completed = true")
   void deleteCompleted();
+
+  List<PaymentOutbox> findByCompleted(boolean completed);
 }

--- a/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/infrastructure/outbox/repository/PaymentOutboxRepository.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/infrastructure/outbox/repository/PaymentOutboxRepository.java
@@ -2,6 +2,7 @@ package io.hhplus.concert_reservation_service_java.domain.payment.infrastructure
 
 import io.hhplus.concert_reservation_service_java.domain.common.outbox.OutboxRepository;
 import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutbox;
+import java.util.List;
 
 public interface PaymentOutboxRepository extends OutboxRepository {
 
@@ -11,4 +12,5 @@ public interface PaymentOutboxRepository extends OutboxRepository {
 
   void deleteCompleted();
 
+  List<PaymentOutbox> findByCompleted(boolean completed);
 }

--- a/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/infrastructure/outbox/repository/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/domain/payment/infrastructure/outbox/repository/PaymentOutboxRepositoryImpl.java
@@ -2,6 +2,7 @@ package io.hhplus.concert_reservation_service_java.domain.payment.infrastructure
 
 import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutbox;
 import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutboxJpaRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +28,11 @@ public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository{
   @Transactional
   public void deleteCompleted() {
     paymentOutboxRepository.deleteCompleted();
+  }
+
+  @Override
+  @Transactional
+  public List<PaymentOutbox> findByCompleted(boolean completed){
+    return paymentOutboxRepository.findByCompleted(completed);
   }
 }

--- a/src/main/java/io/hhplus/concert_reservation_service_java/domain/reservation/application/useCase/CreateReservationUseCaseImpl.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/domain/reservation/application/useCase/CreateReservationUseCaseImpl.java
@@ -52,7 +52,7 @@ public class CreateReservationUseCaseImpl implements CreateReservationUseCase {
 
   private Reservation createAndSaveReservation(User user, ConcertScheduleSeat concertScheduleSeat) {
     Reservation savedReservation = Reservation.builder()
-        .user(user)
+        .userId(user.getId())
         .concertScheduleId(concertScheduleSeat.getConcertSchedule().getId())
         .seatId(concertScheduleSeat.getSeat().getId())
         .status(ReservationStatus.OCCUPIED)

--- a/src/main/java/io/hhplus/concert_reservation_service_java/domain/reservation/infrastructure/jpa/Reservation.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/domain/reservation/infrastructure/jpa/Reservation.java
@@ -35,9 +35,9 @@ public class Reservation {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @ManyToOne
-  @JoinColumn(name = "user_id")
-  private User user;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
 
   @Column(name = "concert_schedule_id", nullable = false)
   private Long concertScheduleId;

--- a/src/main/java/io/hhplus/concert_reservation_service_java/presentation/event/payment/PaymentEventListenerImpl.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/presentation/event/payment/PaymentEventListenerImpl.java
@@ -39,6 +39,7 @@ public class PaymentEventListenerImpl implements PaymentEventListener {
     paymentMessageSender.send(event);
   }
 
+  @Override
   @Async
   @TransactionalEventListener(phase = AFTER_COMMIT)
   public void expireToken(PaymentEvent event) {

--- a/src/main/java/io/hhplus/concert_reservation_service_java/presentation/scheduler/OutboxScheduler.java
+++ b/src/main/java/io/hhplus/concert_reservation_service_java/presentation/scheduler/OutboxScheduler.java
@@ -1,9 +1,21 @@
 package io.hhplus.concert_reservation_service_java.presentation.scheduler;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.PaymentMessageSender;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessage;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessageProducer;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutbox;
 import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.repository.PaymentOutboxRepository;
+import io.hhplus.concert_reservation_service_java.domain.reservation.ReservationService;
+import io.hhplus.concert_reservation_service_java.domain.reservation.infrastructure.jpa.Reservation;
+import io.hhplus.concert_reservation_service_java.domain.reservation.infrastructure.jpa.ReservationStatus;
 import io.hhplus.concert_reservation_service_java.domain.token.TokenService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -11,13 +23,40 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class OutboxScheduler {
+
   private final PaymentOutboxRepository paymentOutboxRepository;
+  private final ReservationService reservationService;
+  private final PaymentKafkaMessageProducer paymentKafkaMessageProducer;
+  private final TokenService tokenService;
 
 
+  @Value("${spring.kafka.topic.payment.name}")
+  private String PAYMENT_TOPIC_NAME;
 
   @Scheduled(fixedRate = 3 * 1000)
   public void scheduler() {
     log.info("scheduler::");
     paymentOutboxRepository.deleteCompleted();
+  }
+
+  @Scheduled(fixedRate = 5 * 1000)
+  public void retryPaymentOutboxEvent() {
+    log.info("retryOutboxEvent::");
+    List<PaymentOutbox> notCompletedOutbox = paymentOutboxRepository.findByCompleted(false);
+    for (PaymentOutbox outbox : notCompletedOutbox){
+      ObjectMapper objectMapper = new ObjectMapper();
+      PaymentKafkaMessage paymentMessage = null;
+      try {
+        paymentMessage = objectMapper.readValue(outbox.getMessage(), PaymentKafkaMessage.class);
+        Reservation reservation = reservationService.getById(paymentMessage.getReservationId());
+
+        if (reservation.getStatus() == ReservationStatus.PAID){
+          paymentKafkaMessageProducer.send(outbox.getMessage());
+        }
+        tokenService.expireToken(paymentMessage.getUserId(), paymentMessage.getAccessKey());
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 }

--- a/src/test/java/io/hhplus/concert_reservation_service_java/integration/useCase/user/CreatePaymentUseCaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/integration/useCase/user/CreatePaymentUseCaseIntegrationTest.java
@@ -3,7 +3,7 @@ package io.hhplus.concert_reservation_service_java.integration.useCase.user;
 
 import io.hhplus.concert_reservation_service_java.domain.payment.application.model.PaymentDomain;
 
-import io.hhplus.concert_reservation_service_java.domain.payment.application.model.port.in.CreatePaymentCommand;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.port.in.CreatePaymentCommand;
 import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.repository.PaymentRepository;
 import io.hhplus.concert_reservation_service_java.domain.reservation.infrastructure.jpa.Reservation;
 import io.hhplus.concert_reservation_service_java.domain.reservation.infrastructure.jpa.ReservationStatus;

--- a/src/test/java/io/hhplus/concert_reservation_service_java/integration/useCase/user/CreatePaymentUseCaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/integration/useCase/user/CreatePaymentUseCaseIntegrationTest.java
@@ -51,7 +51,7 @@ class CreatePaymentUseCaseIntegrationTest {
 
     reservation = Reservation.builder()
         .id(1L)
-        .user(user)
+        .userId(user.getId())
         .concertScheduleId(2L)
         .seatId(3L)
         .reservedPrice(10)

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/service/ReservationServiceTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/service/ReservationServiceTest.java
@@ -69,7 +69,7 @@ class ReservationServiceTest {
     User user = new User(userId, point);
     Reservation reservation = Reservation.builder()
         .id(reservationId)
-        .user(user)
+        .userId(user.getId())
         .status(ReservationStatus.OCCUPIED)
         .createdAt(LocalDateTime.now().minusMinutes(4))
         .build();
@@ -110,7 +110,7 @@ class ReservationServiceTest {
 
     User user = new User(userId, point);
     Reservation reservation = Reservation.builder()
-        .user(user)
+        .userId(user.getId())
         .id(reservationId)
         .status(ReservationStatus.OCCUPIED)
         .createdAt(LocalDateTime.now().minusMinutes(6))
@@ -135,7 +135,7 @@ class ReservationServiceTest {
     User user = new User(differentUserId, 3000);
     Reservation reservation = Reservation.builder()
         .id(reservationId)
-        .user(user)
+        .userId(user.getId())
         .build();
 
     when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/event/PaymentEventListenerTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/event/PaymentEventListenerTest.java
@@ -1,0 +1,151 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.model.PaymentDomain;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.port.in.CreatePaymentCommand;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEvent;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEventListener;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.PaymentMessageSender;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManager;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.repository.jpa.Payment;
+import io.hhplus.concert_reservation_service_java.domain.reservation.infrastructure.jpa.Reservation;
+import io.hhplus.concert_reservation_service_java.domain.token.TokenService;
+import io.hhplus.concert_reservation_service_java.domain.user.infrastructure.jpa.User;
+import io.hhplus.concert_reservation_service_java.presentation.event.payment.PaymentEventListenerImpl;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import static org.mockito.Mockito.*;
+
+@RecordApplicationEvents
+public class PaymentEventListenerTest {
+
+  private final PaymentOutboxManager paymentOutboxManager = Mockito.mock(PaymentOutboxManager.class);
+  private final PaymentMessageSender paymentMessageSender = Mockito.mock(PaymentMessageSender.class);
+
+  private final TokenService tokenService = Mockito.mock(TokenService.class);
+
+  private final PaymentEventListener paymentEventListener = new PaymentEventListenerImpl(
+      paymentOutboxManager, paymentMessageSender, tokenService);
+
+  private CreatePaymentCommand command;
+  private Reservation reservation;
+  private User user;
+  private Payment payment;
+  private PaymentDomain paymentDomain;
+
+  private PaymentEvent paymentEvent;
+
+
+  @BeforeEach
+  void setUp() {
+    String accesskey = UUID.randomUUID().toString();
+    command = CreatePaymentCommand.builder()
+        .userId(1L)
+        .reservationId(1L)
+        .accessKey(accesskey)
+        .build();
+
+    
+    user = new User(1L, 990);
+    reservation = Reservation.builder()
+        .id(1L)
+        .userId(user.getId())
+        .concertScheduleId(2L)
+        .seatId(3L)
+        .reservedPrice(10)
+        .build();
+    payment = Payment.builder()
+        .id(2L)
+        .userId(user.getId())
+        .reservationId(reservation.getId())
+        .createdAt(LocalDateTime.now())
+        .build();
+    paymentDomain = PaymentDomain.builder()
+        .reservationId(reservation.getId())
+        .price(reservation.getReservedPrice())
+        .pointAfter(user.getPoint())
+        .build();
+    PaymentEvent paymentEvent = new PaymentEvent(reservation.getId(), reservation.getReservedPrice(),
+        user.getId(), command.getAccessKey());
+  }
+
+  @Test
+  @DisplayName("이벤트 리스너 성공 :: 아웃박스 생성")
+  void createOutbox_Success() {
+    paymentEventListener.createOutbox(paymentEvent);
+    verify(paymentOutboxManager).create(paymentEvent);
+  }
+
+  @Test
+  @DisplayName("이벤트 리스너 실패 :: 아웃박스 생성 실패")
+  void createOutbox_Failure() {
+    // Arrange: Simulate an exception when create is called
+    doThrow(new RuntimeException("Outbox creation failed"))
+        .when(paymentOutboxManager).create(paymentEvent);
+
+    // Act & Assert: Verify that the exception is thrown
+    assertThatThrownBy(() -> paymentEventListener.createOutbox(paymentEvent))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Outbox creation failed");
+
+    // Optionally verify that create was called once
+    verify(paymentOutboxManager).create(paymentEvent);
+  }
+
+  @Test
+  @DisplayName("이벤트 리스너 성공 :: 메시지 전송")
+  void sendMessage_Success() {
+    paymentEventListener.sendMessage(paymentEvent);
+    verify(paymentMessageSender).send(paymentEvent);
+  }
+
+  @Test
+  @DisplayName("이벤트 리스너 실패 :: 메시지 전송 실패")
+  void sendMessage_Failure() {
+    // Arrange: Simulate an exception when send is called
+    doThrow(new RuntimeException("Message sending failed"))
+        .when(paymentMessageSender).send(paymentEvent);
+
+    // Act & Assert: Verify that the exception is thrown
+    assertThatThrownBy(() -> paymentEventListener.sendMessage(paymentEvent))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Message sending failed");
+
+    // Optionally verify that send was called once
+    verify(paymentMessageSender).send(paymentEvent);
+  }
+
+  @Test
+  @DisplayName("이벤트 리스너 성공 :: 토큰 만료")
+  void execute_Success_expireToken() throws JsonProcessingException {
+    paymentEventListener.expireToken(paymentEvent);
+    verify(tokenService).expireToken(user.getId(), command.getAccessKey());
+  }
+
+  @Test
+  @DisplayName("이벤트 리스너 실패 :: 토큰 만료")
+  void execute_Failure_expireToken() throws JsonProcessingException {
+    doThrow(new RuntimeException("Token expiration failed"))
+        .when(tokenService).expireToken(user.getId(), command.getAccessKey());
+
+    PaymentEvent paymentEvent = new PaymentEvent(reservation.getId(), reservation.getReservedPrice(),
+        user.getId(), command.getAccessKey());
+
+    assertThatThrownBy(() -> paymentEventListener.expireToken(paymentEvent))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Token expiration failed");
+
+    // Optionally verify that expireToken was called once
+    verify(tokenService, times(1)).expireToken(user.getId(), command.getAccessKey());
+  }
+
+}

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/event/PaymentEventPublisherTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/event/PaymentEventPublisherTest.java
@@ -1,0 +1,166 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.event;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.hhplus.concert_reservation_service_java.domain.payment.CreatePaymentUseCase;
+import io.hhplus.concert_reservation_service_java.domain.payment.PaymentService;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.model.PaymentDomain;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.port.in.CreatePaymentCommand;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.useCase.CreatePaymentUseCaseImpl;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEvent;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEventListener;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEventPublisher;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.PaymentMessageSender;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManager;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.repository.jpa.Payment;
+import io.hhplus.concert_reservation_service_java.domain.reservation.ReservationService;
+import io.hhplus.concert_reservation_service_java.domain.reservation.infrastructure.jpa.Reservation;
+import io.hhplus.concert_reservation_service_java.domain.token.TokenService;
+import io.hhplus.concert_reservation_service_java.domain.user.UserService;
+import io.hhplus.concert_reservation_service_java.domain.user.application.port.out.PaymentMapper;
+import io.hhplus.concert_reservation_service_java.domain.user.infrastructure.jpa.User;
+import io.hhplus.concert_reservation_service_java.exception.CustomException;
+import io.hhplus.concert_reservation_service_java.exception.ErrorCode;
+import io.hhplus.concert_reservation_service_java.presentation.event.payment.PaymentEventListenerImpl;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+
+public class PaymentEventPublisherTest {
+
+  private final UserService userService = Mockito.mock(UserService.class);
+  private final ReservationService reservationService = Mockito.mock(ReservationService.class);
+  private final PaymentService paymentService = Mockito.mock(PaymentService.class);
+  private final TokenService tokenService = Mockito.mock(TokenService.class);
+
+  private final PaymentEventPublisher eventPublisher = Mockito.mock(PaymentEventPublisher.class);
+
+  private final PaymentMapper paymentMapper = Mockito.mock(PaymentMapper.class);
+
+
+
+  private final CreatePaymentUseCase createPaymentUseCase = new CreatePaymentUseCaseImpl(
+      userService, reservationService, paymentService , tokenService, eventPublisher, paymentMapper);
+
+  private CreatePaymentCommand command;
+  private Reservation reservation;
+  private User user;
+  private Payment payment;
+  private PaymentDomain paymentDomain;
+
+
+  @BeforeEach
+  void setUp() {
+    String accesskey = UUID.randomUUID().toString();
+    command = CreatePaymentCommand.builder()
+        .userId(1L)
+        .reservationId(1L)
+        .accessKey(accesskey)
+        .build();
+
+    
+    user = new User(1L, 990);
+    reservation = Reservation.builder()
+        .id(1L)
+        .userId(user.getId())
+        .concertScheduleId(2L)
+        .seatId(3L)
+        .reservedPrice(10)
+        .build();
+    payment = Payment.builder()
+        .id(2L)
+        .userId(user.getId())
+        .reservationId(reservation.getId())
+        .createdAt(LocalDateTime.now())
+        .build();
+    paymentDomain = PaymentDomain.builder()
+        .reservationId(reservation.getId())
+        .price(reservation.getReservedPrice())
+        .pointAfter(user.getPoint())
+        .build();
+  }
+
+  @Test
+  @DisplayName("이벤트 발행 성공")
+  void execute_Success_expireToken() throws JsonProcessingException {
+
+    when(reservationService.getReservationToPay(1L)).thenReturn(reservation);
+    when(userService.usePoint(1L, reservation.getReservedPrice())).thenReturn(user);
+    when(reservationService.saveToPay(reservation)).thenReturn(reservation);
+    when(paymentMapper.of(reservation, user)).thenReturn(paymentDomain);
+
+    // When
+    PaymentDomain result = createPaymentUseCase.execute(command);
+
+    // Then
+    assertEquals(paymentDomain, result);
+    verify(reservationService).getReservationToPay(reservation.getId());
+    verify(userService).usePoint(1L, 10);
+    verify(reservationService).saveToPay(reservation);
+
+    verify(paymentMapper).of(reservation, user);
+
+    ArgumentCaptor<PaymentEvent> eventCaptor = ArgumentCaptor.forClass(PaymentEvent.class);
+    verify(eventPublisher).execute(eventCaptor.capture());
+    PaymentEvent event = eventCaptor.getValue();
+    assertEquals(reservation.getId(), event.getReservationId());
+    assertEquals(user.getId(), event.getUserId());
+  }
+
+  @Test
+  @DisplayName("이벤트 발행 실패 :: 예약 찾을 수 없음")
+  void execute_Failure_expireToken() throws JsonProcessingException {
+    when(reservationService.getReservationToPay(1L))
+        .thenThrow(new CustomException(ErrorCode.RESERVATION_NOT_FOUND));
+
+
+    // Act & Assert
+    assertThatThrownBy(() -> createPaymentUseCase.execute(command))
+        .isInstanceOf(CustomException.class)
+        .satisfies(thrown -> {
+          CustomException exception = (CustomException) thrown;
+          assertEquals(ErrorCode.RESERVATION_NOT_FOUND, exception.getErrorCode());
+        });
+
+    verify(reservationService).getReservationToPay(1L);
+    verify(userService, never()).getUserWithLock(user.getId());
+    verify(eventPublisher, never()).execute(any());
+    verifyNoMoreInteractions(reservationService, userService, eventPublisher);
+  }
+
+  @Test
+  @DisplayName("이벤트 발행 실패 :: 충분하지 않은 포인트")
+  void execute_WhenNotEnoughPoints_ShouldThrowException() {
+    // Given
+    when(reservationService.getReservationToPay(1L)).thenReturn(reservation);
+    when(userService.usePoint(1L, reservation.getReservedPrice())).thenThrow(new CustomException(ErrorCode.NOT_ENOUGH_POINT));
+    when(paymentService.createPayment(1L, reservation)).thenReturn(payment);
+    when(paymentMapper.of(reservation, user)).thenReturn(paymentDomain);;
+
+    // When & Then
+    assertThatThrownBy(() -> createPaymentUseCase.execute(command))
+        .isInstanceOf(CustomException.class)
+        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_ENOUGH_POINT);
+
+    verify(reservationService).getReservationToPay(reservation.getId());
+    verify(userService).usePoint(user.getId(), reservation.getReservedPrice());
+    verify(eventPublisher, never()).execute(any());
+    verifyNoMoreInteractions(reservationService, userService, eventPublisher);
+  }
+
+}

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/PaymentMessageSenderTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/PaymentMessageSenderTest.java
@@ -1,0 +1,62 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.message;
+
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEvent;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.PaymentMessageSender;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.PaymentMessageSenderImpl;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessageProducer;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManager;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManagerImpl;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutbox;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class PaymentMessageSenderTest {
+  private final PaymentKafkaMessageProducer paymentKafkaMessageProducer = Mockito.mock(PaymentKafkaMessageProducer.class);
+  private final PaymentMessageSender paymentMessageSender = new PaymentMessageSenderImpl(paymentKafkaMessageProducer);
+
+  private PaymentEvent paymentEvent;
+  private PaymentOutbox paymentOutbox;
+
+  @BeforeEach
+  void setUp() {
+    String accesskey = UUID.randomUUID().toString();
+
+    paymentEvent = new PaymentEvent(1L, 10, 1L, accesskey);
+    paymentEvent.createOutboxMessage();
+    paymentOutbox = paymentEvent.getPaymentOutbox();
+  }
+
+  @Test
+  @DisplayName("메시지 전송 성공")
+  void send_Success() {
+    paymentEvent.createKafkaMessage();
+    paymentMessageSender.send(paymentEvent);
+    verify(paymentKafkaMessageProducer, times(1)).send(paymentEvent.getMessage());
+  }
+
+  @Test
+  @DisplayName("메시지 전송 실패")
+  void send_Failure() {
+    // Arrange
+    paymentEvent.createKafkaMessage(); // Assume this sets the message in the event
+    doThrow(new RuntimeException("메시지 전송 실패"))
+        .when(paymentKafkaMessageProducer).send(paymentEvent.getMessage());
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentMessageSender.send(paymentEvent))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("메시지 전송 실패");
+
+    // Verify that the send method was indeed called
+    verify(paymentKafkaMessageProducer).send(paymentEvent.getMessage());
+  }
+}

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/kafka/PaymentKafkaMessageConsumerTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/kafka/PaymentKafkaMessageConsumerTest.java
@@ -1,0 +1,166 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.message.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert_reservation_service_java.domain.common.message.MessageSender;
+import io.hhplus.concert_reservation_service_java.domain.payment.PaymentService;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessage;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManager;
+import io.hhplus.concert_reservation_service_java.domain.token.TokenService;
+import io.hhplus.concert_reservation_service_java.presentation.consumer.PaymentKafkaMessageConsumer;
+import io.hhplus.concert_reservation_service_java.presentation.consumer.PaymentKafkaMessageConsumerImpl;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import static org.mockito.Mockito.*;
+
+public class PaymentKafkaMessageConsumerTest {
+
+  private final PaymentOutboxManager paymentOutboxManager = Mockito.mock(PaymentOutboxManager.class);
+
+  private final MessageSender messageSender = Mockito.mock(MessageSender.class);
+
+  private final PaymentService paymentService = Mockito.mock(PaymentService.class);
+
+  private final TokenService tokenService = Mockito.mock(TokenService.class);
+
+  private final PaymentKafkaMessageConsumer paymentKafkaMessageConsumer = new PaymentKafkaMessageConsumerImpl(paymentOutboxManager, messageSender, paymentService, tokenService);
+
+  private KafkaMessageListenerContainer<String, String> container;
+  private CountDownLatch latch = new CountDownLatch(1);
+  private String receivedMessage;
+
+  @BeforeEach
+  void setUp() {
+  }
+
+  @Test
+  @DisplayName("paidToMarkOutBox 성공")
+  public void testPaidToMarkOutBox() throws Exception {
+    // Arrange
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+
+    paymentKafkaMessageConsumer.paidToMarkOutBox(message);
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+    verify(paymentOutboxManager, times(1)).markComplete(paymentMessage.getOutboxId());
+  }
+
+  @Test
+  @DisplayName("paidToMarkOutBox 실패 - JSON 처리 오류")
+  public void testPaidToMarkOutBox_Failure_JsonProcessingException() {
+    // Arrange
+    String malformedMessage = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11"; // Missing closing brace
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentKafkaMessageConsumer.paidToMarkOutBox(malformedMessage))
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(JsonProcessingException.class);
+
+    // Verify that markComplete was never called due to the exception
+    verify(paymentOutboxManager, never()).markComplete(anyLong());
+  }
+
+  @Test
+  @DisplayName("paidToMarkOutBox 실패 - markComplete 호출 시 예외 발생")
+  public void testPaidToMarkOutBox_Failure_MarkCompleteException() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+
+    doThrow(new RuntimeException("Failed to mark complete"))
+        .when(paymentOutboxManager).markComplete(paymentMessage.getOutboxId());
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentKafkaMessageConsumer.paidToMarkOutBox(message))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to mark complete");
+
+    // Verify that markComplete was called once, but it threw an exception
+    verify(paymentOutboxManager, times(1)).markComplete(paymentMessage.getOutboxId());
+  }
+
+  @Test
+  @DisplayName("paidToCreatePayment 성공")
+  public void testPaidToCreatePayment_Success() throws Exception {
+    // Arrange
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+
+    // Act
+    paymentKafkaMessageConsumer.paidToCreatePayment(message);
+
+    // Assert
+    verify(paymentService, times(1)).createPayment(
+        paymentMessage.getUserId(),
+        paymentMessage.getReservationId(),
+        paymentMessage.getReservedPrice()
+    );
+  }
+
+  @Test
+  @DisplayName("paidToCreatePayment 실패 - JSON 처리 오류")
+  public void testPaidToCreatePayment_Failure_JsonProcessingException() {
+    // Arrange
+    String malformedMessage = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1"; // Missing closing brace
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentKafkaMessageConsumer.paidToCreatePayment(malformedMessage))
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(JsonProcessingException.class);
+
+    // Verify that createPayment was never called due to the exception
+    verify(paymentService, never()).createPayment(anyLong(), anyLong(), anyInt());
+  }
+
+  @Test
+  @DisplayName("paidToCreatePayment 실패 - createPayment 호출 시 예외 발생")
+  public void testPaidToCreatePayment_Failure_CreatePaymentException() throws Exception {
+    // Arrange
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+
+    doThrow(new RuntimeException("Failed to create payment"))
+        .when(paymentService).createPayment(paymentMessage.getUserId(), paymentMessage.getReservationId(), paymentMessage.getReservedPrice());
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentKafkaMessageConsumer.paidToCreatePayment(message))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to create payment");
+
+    // Verify that createPayment was called once, but it threw an exception
+    verify(paymentService, times(1)).createPayment(paymentMessage.getUserId(), paymentMessage.getReservationId(), paymentMessage.getReservedPrice());
+  }
+}

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/kafka/PaymentKafkaMessageProducerTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/kafka/PaymentKafkaMessageProducerTest.java
@@ -1,0 +1,75 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.message.kafka;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEvent;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessageProducer;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessageProducerImpl;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManager;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutbox;
+import java.util.UUID;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import java.util.Map;
+
+public class PaymentKafkaMessageProducerTest {
+
+  private KafkaTemplate<String, String> kafkaTemplate = Mockito.mock(KafkaTemplate.class);
+  private final PaymentKafkaMessageProducer paymentKafkaMessageProducer = new PaymentKafkaMessageProducerImpl(
+      kafkaTemplate
+  );
+  private PaymentEvent paymentEvent;
+  private PaymentOutbox paymentOutbox;
+  private String message;
+
+  @BeforeEach
+  void setUp() {
+    String accesskey = UUID.randomUUID().toString();
+
+    paymentEvent = new PaymentEvent(1L, 10, 1L, accesskey);
+    paymentEvent.createOutboxMessage();
+    paymentOutbox = paymentEvent.getPaymentOutbox();
+    message = paymentOutbox.getMessage();
+  }
+
+  @Test
+  @DisplayName("카프카 메시지 전송 성공")
+  void produce_Success() throws Exception {
+    paymentKafkaMessageProducer.send(message);
+    verify(kafkaTemplate, times(1)).send(null,message);
+  }
+
+  @Test
+  @DisplayName("카프카 메시지 전송 실패")
+  void send_Failure() {
+    // Arrange
+    String message = "Test message";
+    doThrow(new RuntimeException("Failed to send message"))
+        .when(kafkaTemplate).send(null, message);
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentKafkaMessageProducer.send(message))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to send message");
+
+    // Verify that the send method was indeed called
+    verify(kafkaTemplate).send(null, message);
+  }
+}

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/kafka/PaymnetKafkaMessageIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/message/kafka/PaymnetKafkaMessageIntegrationTest.java
@@ -1,0 +1,209 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.message.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert_reservation_service_java.domain.common.message.MessageSender;
+import io.hhplus.concert_reservation_service_java.domain.payment.PaymentService;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessage;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManager;
+import io.hhplus.concert_reservation_service_java.domain.token.TokenService;
+import io.hhplus.concert_reservation_service_java.presentation.consumer.PaymentKafkaMessageConsumer;
+import io.hhplus.concert_reservation_service_java.presentation.consumer.PaymentKafkaMessageConsumerImpl;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = { "payment_test" })
+public class PaymnetKafkaMessageIntegrationTest {
+
+  @Autowired
+  private KafkaTemplate<String, String> kafkaTemplate;
+
+  private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+  private final PaymentOutboxManager paymentOutboxManager = Mockito.mock(PaymentOutboxManager.class);
+
+  private final MessageSender messageSender = Mockito.mock(MessageSender.class);
+
+  private final PaymentService paymentService = Mockito.mock(PaymentService.class);
+
+  private final TokenService tokenService = Mockito.mock(TokenService.class);
+
+  private final PaymentKafkaMessageConsumer paymentKafkaMessageConsumer = new PaymentKafkaMessageConsumerImpl(paymentOutboxManager, messageSender, paymentService, tokenService);
+
+
+  private KafkaMessageListenerContainer<String, String> container;
+  private CountDownLatch latch = new CountDownLatch(1);
+  private String receivedMessage;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "true", embeddedKafkaBroker);
+    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    ConsumerFactory<String, String> consumerFactory = new DefaultKafkaConsumerFactory<>(consumerProps, new StringDeserializer(), new StringDeserializer());
+    ContainerProperties containerProperties = new ContainerProperties("payment_test");
+    container = new KafkaMessageListenerContainer<>(consumerFactory, containerProperties);
+    container.setupMessageListener((MessageListener<String, String>) record -> {
+      receivedMessage = record.value();
+      latch.countDown();
+    });
+    container.start();
+  }
+
+  @AfterEach
+  void tearDown() {
+    container.stop();
+  }
+
+  @Test
+  @DisplayName("paidToMarkOutBox 성공")
+  public void testPaidToMarkOutBox_Success() throws Exception {
+    // Arrange
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+
+    // Act
+    paymentKafkaMessageConsumer.paidToMarkOutBox(message);
+
+    // Assert
+    verify(paymentOutboxManager, times(1)).markComplete(paymentMessage.getOutboxId());
+  }
+
+  @Test
+  @DisplayName("paidToMarkOutBox 실패 - JSON 처리 오류")
+  public void testPaidToMarkOutBox_Failure_JsonProcessingException() {
+    // Arrange
+    String malformedMessage = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1"; // Missing closing brace
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentKafkaMessageConsumer.paidToMarkOutBox(malformedMessage))
+        .isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(JsonProcessingException.class);
+
+    // Verify that markComplete was never called due to the exception
+    verify(paymentOutboxManager, never()).markComplete(anyLong());
+  }
+
+  @Test
+  public void createPayment_success_ProduceAndConsume() throws Exception {
+    // Arrange
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+
+    // Act: Produce the message
+    kafkaTemplate.send("payment_test", message);
+
+    // Assert: Consume the message
+    assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    assertThat(receivedMessage).isEqualTo(message);
+
+    // Verify that the consumer processed the message
+    verify(paymentService, times(1)).createPayment(
+        paymentMessage.getUserId(),
+        paymentMessage.getReservationId(),
+        paymentMessage.getReservedPrice()
+    );
+  }
+
+  @Test
+  @DisplayName("paidToMarkOutBox 실패 - markComplete 호출 시 예외 발생")
+  public void testPaidToMarkOutBox_Failure_MarkCompleteException() throws Exception {
+    // Arrange
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+
+    doThrow(new RuntimeException("Failed to mark complete"))
+        .when(paymentOutboxManager).markComplete(paymentMessage.getOutboxId());
+
+    // Act & Assert
+    assertThatThrownBy(() -> paymentKafkaMessageConsumer.paidToMarkOutBox(message))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to mark complete");
+
+    // Verify that markComplete was called once, but it threw an exception
+    verify(paymentOutboxManager, times(1)).markComplete(paymentMessage.getOutboxId());
+  }
+
+  @Test
+  @DisplayName("createPayment 실패 - JSON 처리 오류")
+  public void createPayment_Failure_JsonProcessingException() throws Exception {
+    // Arrange
+    String malformedMessage = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1"; // Missing closing brace
+
+    // Act: Produce the malformed message
+    kafkaTemplate.send("payment_test", malformedMessage);
+
+    // Assert: Wait for the message to be consumed and expect an exception
+    assertThatThrownBy(() -> {
+      latch.await(10, TimeUnit.SECONDS);
+      paymentKafkaMessageConsumer.paidToCreatePayment(malformedMessage);
+    }).isInstanceOf(RuntimeException.class)
+        .hasCauseInstanceOf(JsonProcessingException.class);
+
+    // Verify that createPayment was never called due to the exception
+    verify(paymentService, never()).createPayment(anyLong(), anyLong(), anyInt());
+  }
+
+  @Test
+  @DisplayName("createPayment 실패 - createPayment 호출 시 예외 발생")
+  public void createPayment_Failure_CreatePaymentException() throws Exception {
+    // Arrange
+    String message = "{\"reservationId\":1,\"reservedPrice\":10,\"userId\":1,\"accessKey\":null,\"outboxId\":11}";
+    ObjectMapper objectMapper = new ObjectMapper();
+    PaymentKafkaMessage paymentMessage = objectMapper.readValue(message, PaymentKafkaMessage.class);
+
+    doThrow(new RuntimeException("Failed to create payment"))
+        .when(paymentService).createPayment(paymentMessage.getUserId(), paymentMessage.getReservationId(), paymentMessage.getReservedPrice());
+
+    // Act: Produce the message
+    kafkaTemplate.send("payment_test", message);
+
+    // Assert: Wait for the message to be consumed and expect an exception
+    assertThatThrownBy(() -> {
+      latch.await(10, TimeUnit.SECONDS);
+      paymentKafkaMessageConsumer.paidToCreatePayment(message);
+    }).isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to create payment");
+
+    // Verify that createPayment was called once, but it threw an exception
+    verify(paymentService, times(1)).createPayment(paymentMessage.getUserId(), paymentMessage.getReservationId(), paymentMessage.getReservedPrice());
+  }
+}

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/outbox/PaymnetOutboxManagerTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/outbox/PaymnetOutboxManagerTest.java
@@ -1,0 +1,87 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.outbox;
+
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEvent;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManager;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.PaymentOutboxManagerImpl;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutbox;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.repository.PaymentOutboxRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+import static org.mockito.Mockito.*;
+
+public class PaymnetOutboxManagerTest {
+
+  private final PaymentOutboxRepository paymentOutboxRepository = Mockito.mock(PaymentOutboxRepository.class);
+
+  private final PaymentOutboxManager paymentOutboxManager = new PaymentOutboxManagerImpl(paymentOutboxRepository);
+
+  private PaymentEvent paymentEvent;
+  private PaymentOutbox paymentOutbox;
+
+  @BeforeEach
+  void setUp() {
+    String accesskey = UUID.randomUUID().toString();
+
+    paymentEvent = new PaymentEvent(1L, 10, 1L, accesskey);
+    paymentEvent.createOutboxMessage();
+    paymentOutbox = paymentEvent.getPaymentOutbox();
+  }
+
+  @Test
+  @DisplayName("아웃박스 생성 성공")
+  void create_Success() {
+
+    when(paymentOutboxRepository.save(any(PaymentOutbox.class))).thenReturn(paymentOutbox);
+
+    PaymentOutbox result = paymentOutboxManager.create(paymentEvent);
+
+    verify(paymentOutboxRepository).save(paymentEvent.getPaymentOutbox());
+    assertEquals(paymentOutbox, result);
+  }
+
+  @Test
+  @DisplayName("아웃박스 생성 실패")
+  void create_Failure() {
+    doThrow(new RuntimeException("Failed to save outbox"))
+        .when(paymentOutboxRepository).save(any(PaymentOutbox.class));
+
+    assertThatThrownBy(() -> paymentOutboxManager.create(paymentEvent))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to save outbox");
+
+    verify(paymentOutboxRepository).save(paymentEvent.getPaymentOutbox());
+  }
+
+
+  @Test
+  @DisplayName("아웃박스 완료 마크 성공")
+  void markComplete_Success() {
+    long outboxId = 1L;
+    paymentOutboxManager.markComplete(outboxId);
+    verify(paymentOutboxRepository).markComplete(outboxId);
+  }
+
+  @Test
+  @DisplayName("아웃박스 완료 마크 실패")
+  void markComplete_Failure() {
+
+    long outboxId = 1L;
+    doThrow(new RuntimeException("아웃박스 완료 마크 실패"))
+        .when(paymentOutboxRepository).markComplete(outboxId);
+
+
+    assertThatThrownBy(() -> paymentOutboxManager.markComplete(outboxId))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("아웃박스 완료 마크 실패");
+    verify(paymentOutboxRepository).markComplete(outboxId);
+  }
+}

--- a/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/outbox/SchedulerTest.java
+++ b/src/test/java/io/hhplus/concert_reservation_service_java/unit/useCase/payment/outbox/SchedulerTest.java
@@ -1,0 +1,108 @@
+package io.hhplus.concert_reservation_service_java.unit.useCase.payment.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.model.PaymentDomain;
+import io.hhplus.concert_reservation_service_java.domain.payment.application.port.in.CreatePaymentCommand;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.event.PaymentEvent;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessage;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.message.kafka.PaymentKafkaMessageProducer;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.jpa.PaymentOutbox;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.outbox.repository.PaymentOutboxRepository;
+import io.hhplus.concert_reservation_service_java.domain.payment.infrastructure.repository.jpa.Payment;
+import io.hhplus.concert_reservation_service_java.domain.reservation.ReservationService;
+import io.hhplus.concert_reservation_service_java.domain.reservation.infrastructure.jpa.Reservation;
+import io.hhplus.concert_reservation_service_java.domain.token.TokenService;
+import io.hhplus.concert_reservation_service_java.domain.user.infrastructure.jpa.User;
+import io.hhplus.concert_reservation_service_java.presentation.scheduler.OutboxScheduler;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.*;
+
+public class SchedulerTest {
+
+  private final PaymentOutboxRepository paymentOutboxRepository = Mockito.mock(PaymentOutboxRepository.class);
+  private final ReservationService reservationService = Mockito.mock(ReservationService.class);
+  private final PaymentKafkaMessageProducer paymentKafkaMessageProducer = Mockito.mock(PaymentKafkaMessageProducer.class);
+  private final TokenService tokenService = Mockito.mock(TokenService.class);
+
+  private final ObjectMapper objectMapper = Mockito.mock(ObjectMapper.class);
+
+  private final OutboxScheduler outboxScheduler = new OutboxScheduler(paymentOutboxRepository, reservationService, paymentKafkaMessageProducer, tokenService);
+
+  private Reservation reservation;
+  private User user;
+  private Payment payment;
+  private PaymentDomain paymentDomain;
+  private PaymentEvent paymentEvent;
+  @BeforeEach
+  void setUp() {
+    String accesskey = UUID.randomUUID().toString();
+    user = new User(1L, 990);
+    reservation = Reservation.builder()
+        .id(1L)
+        .userId(user.getId())
+        .concertScheduleId(2L)
+        .seatId(3L)
+        .reservedPrice(10)
+        .build();
+    payment = Payment.builder()
+        .id(2L)
+        .userId(user.getId())
+        .reservationId(reservation.getId())
+        .createdAt(LocalDateTime.now())
+        .build();
+    paymentDomain = PaymentDomain.builder()
+        .reservationId(reservation.getId())
+        .price(reservation.getReservedPrice())
+        .pointAfter(user.getPoint())
+        .build();
+    paymentEvent = new PaymentEvent(reservation.getId(), reservation.getReservedPrice(),
+        user.getId(), accesskey);
+  }
+  @Test
+  @DisplayName("아웃박스 이벤트 발행 재시도 성공")
+  void retryPaymentOutboxEvent_Success() throws JsonProcessingException {
+    // Arrange
+    paymentEvent.createOutboxMessage();
+    PaymentOutbox outbox = paymentEvent.getPaymentOutbox();
+
+    List<PaymentOutbox> outboxList = Arrays.asList(outbox);
+
+    when(paymentOutboxRepository.findByCompleted(false)).thenReturn(outboxList);
+
+    when(reservationService.getById(any(Long.class))).thenReturn(reservation);
+
+    outboxScheduler.retryPaymentOutboxEvent();
+
+    verify(tokenService).expireToken(any(Long.class), any(String.class));
+  }
+
+  @Test
+  @DisplayName("아웃박스 이벤트 발행 재시도 실패 - JSON 처리 오류")
+  void retryPaymentOutboxEvent_Failure_JsonProcessingException() throws JsonProcessingException {
+    // Arrange
+    paymentEvent.createOutboxMessage();
+    PaymentOutbox outbox = paymentEvent.getPaymentOutbox();
+
+    List<PaymentOutbox> outboxList = Arrays.asList(outbox);
+
+    when(paymentOutboxRepository.findByCompleted(false)).thenReturn(outboxList);
+    when(objectMapper.readValue(outbox.getMessage(), PaymentKafkaMessage.class))
+        .thenThrow(new JsonProcessingException("JSON processing error") {});
+
+    // Act & Assert
+    try {
+      outboxScheduler.retryPaymentOutboxEvent();
+    } catch (RuntimeException e) {
+      verify(paymentKafkaMessageProducer, never()).send(anyString());
+      verify(tokenService, never()).expireToken(anyLong(), anyString());
+    }
+  }
+}


### PR DESCRIPTION
# 변경사항
1. 카프카 메세지 발행 및 소비 테스트
	- PaymentEventListener  [21ce21d](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/21ce21dd466a2c708d15046772da11e16413cda2)
	- PaymentMessageSender   [9cb89b4](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/9cb89b4148ab7ad29716f2a0186cf9e7cb6b715a)
	- PaymentKafkaMessageProducer [4636034](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/46360347ada5bd728a868403d6b80b68f43c47f7)
	- PaymentKafkaMessageConsumer [48bba93](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/48bba93669837c68a2cb3d2153febc8b09916045)
	- PaymentKafkaMessage   [49b5857](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/49b5857e9c33a7f364e69abf80a7b95bb6b83809)


1. 아웃박스 로직 테스트
	- CreatePaymentUseCase [c3bc009](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/c3bc00987d4552b24bc053cd62794e87bcf005d9)
	- PaymentEventPublisher  [21ce21d](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/21ce21dd466a2c708d15046772da11e16413cda2)
	- PaymentOutboxManager   [c3d2938](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/c3d29389d541c3f16f47a9e4fce713bb254f0980)

1. 스케줄러 로직 테스트
	- OutboxScheduler   [7026b95](https://github.com/adiospain/hhplus-concert-reservation-service-java/pull/18/commits/7026b958281743c99218c359ff12917826c33811)
  
# 리뷰 포인트
1.  UseCase로 부터 Kafka 컨슈머 단계까지 단위테스트로만 작성했는데 UseCase 통합테스트로서 카프카 테스트는 어떻게 작성하면 좋을지 피드백 부탁드립니다.

# 추후 개선
1. 각 도메인 로직 별 예외처리